### PR TITLE
LRDOCS-3809 Source Formatter (Maven) reference article

### DIFF
--- a/develop/reference/articles/11-maven/source-formatter-plugin.markdown
+++ b/develop/reference/articles/11-maven/source-formatter-plugin.markdown
@@ -1,0 +1,80 @@
+# Source Formatter Plugin
+
+The Source Formatter Gradle plugin lets you format project files using the
+Liferay Source Formatter tool.
+
+## Usage
+
+To use the plugin, include it in your `pom.xml` file:
+
+    <build>
+        <plugins>
+        ...
+            <plugin>
+                <groupId>com.liferay</groupId>
+                <artifactId>com.liferay.source.formatter</artifactId>
+                <version>1.0.432</version>
+                <executions>
+                    <execution>
+                        <phase>process-sources</phase>
+                        <goals>
+                            <goal>format</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                </configuration>
+            </plugin
+        ...
+        </plugins>
+    </build>
+
+## Goals
+
+The plugin adds one Maven goal to your project:
+
+Name | Description
+---- | -----------
+`format` |  Runs the Liferay Source Formatter to format source formatting errors.
+
+## Available Parameters
+
+You can set the following parameters in the `<configuration>` section of the
+POM:
+
+Parameter Name | Type | Default Value | Description
+------------- | ---- | ------------- | -----------
+`autoFix` | `boolean` | `false` | Whether to automatically fix source formatting errors.
+`baseDir` | `File` |  | The Source Formatter base directory. *(Read-only)*
+`fileNames` | `List<String>` | `null` | The file names to format, relative to the project directory. If `null`, all files contained in `baseDir` will be formatted.
+`formatCurrentBranch` | `boolean` | `false` | Whether to format only the files contained in `baseDir` that are added or modified in the current Git branch.
+`formatLatestAuthor` | `boolean` | `false` | Whether to format only the files contained in `baseDir` that are added or modified in the latest Git commits of the same author.
+`formatLocalChanges` | `boolean` | `false` | Whether to format only the unstaged files contained in `baseDir`.
+`gitWorkingBranchName` | `String` | `"master"` | The Git working branch name.
+`includeSubrepositories` | `boolean` | `false` | Whether to format files that are in read-only subrepositories.
+`maxLineLength` | `int` | `80` | The maximum number of characters allowed in Java files.
+`printErrors` | `boolean` | `true` | Whether to print formatting errors on the Standard Output stream.
+`processorThreadCount` | `int` | `5` | The number of threads used by Source Formatter.
+`showDocumentation` | `boolean` | `true` | Whether to show the documentation for the source formatting issues, if present.
+`throwException` | `boolean` | `false` | Whether to fail the build if formatting errors are found.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+


### PR DESCRIPTION
Hey Andrea,

I'm creating a reference article for applying the Source Formatter plugin to Maven projects. I would like to begin reproducing the articles you created for the Gradle plugins for Maven, and this is the first of hopefully many conversions. I've outlined a simple draft for the SF Maven plugin based on your SF Gradle plugin [README](https://github.com/liferay/liferay-portal/blob/master/modules/sdk/gradle-plugins-source-formatter/README.markdown).

Can you take a look and provide any suggestions you think should be added/modified? Your Gradle version is much more detailed, but I'm unsure of what the differences are between the Gradle and Maven plugin configurations, so I don't know what else to add (or how to find it). I basically ran `mvn help:describe -DgroupId=com.liferay -DartifactId=com.liferay.source.formatter -Ddetail=true` and transferred that info into the article.

Let me know what you think. Thanks!